### PR TITLE
Header type validation

### DIFF
--- a/specs/specs.go
+++ b/specs/specs.go
@@ -13,6 +13,7 @@ type Object interface {
 	GetNestedProperties() map[string]*NestedParameterMap
 	GetRepeatedProperties() map[string]*RepeatedParameterMap
 	GetLabel() types.Label
+	GetHeader() Header
 }
 
 // FlowCaller represents a flow caller
@@ -187,6 +188,11 @@ func (parameters *ParameterMap) GetRepeatedProperties() map[string]*RepeatedPara
 	return parameters.Repeated
 }
 
+// GetHeader returns the parameter map header
+func (parameters *ParameterMap) GetHeader() Header {
+	return parameters.Header
+}
+
 // GetLabel returns the parameter map label
 func (parameters *ParameterMap) GetLabel() types.Label {
 	return types.LabelOptional
@@ -234,6 +240,11 @@ func (nested *NestedParameterMap) GetType() types.Type {
 // GetObject returns the nested parameter map type
 func (nested *NestedParameterMap) GetObject() Object {
 	return nested
+}
+
+// GetHeader returns the nested parameter map header
+func (nested *NestedParameterMap) GetHeader() Header {
+	return nil
 }
 
 // GetLabel returns the nested parameter map label
@@ -309,6 +320,11 @@ func (repeated *RepeatedParameterMap) GetType() types.Type {
 // GetObject returns the repeated parameter map type
 func (repeated *RepeatedParameterMap) GetObject() Object {
 	return repeated
+}
+
+// GetHeader returns the repeated parameter map header
+func (repeated *RepeatedParameterMap) GetHeader() Header {
+	return nil
 }
 
 // GetLabel returns the repeated parameter map label

--- a/specs/strict/define.go
+++ b/specs/strict/define.go
@@ -139,6 +139,13 @@ func DefineCall(schema schema.Collection, manifest *specs.Manifest, call specs.F
 
 // DefineParameterMap defines the types for the given parameter map
 func DefineParameterMap(call specs.FlowCaller, params specs.Object, flow specs.FlowManager) (err error) {
+	for _, header := range params.GetHeader() {
+		err = DefineProperty(call, header, flow)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, property := range params.GetProperties() {
 		err = DefineProperty(call, property, flow)
 		if err != nil {
@@ -198,6 +205,12 @@ func DefineProperty(call specs.FlowCaller, property *specs.Property, flow specs.
 
 // CheckTypes checks the given call against the given schema method types
 func CheckTypes(object specs.Object, message schema.Object, flow specs.FlowManager) (err error) {
+	for _, header := range object.GetHeader() {
+		if header.GetType() != types.TypeString {
+			return trace.New(trace.WithMessage("cannot use type %s for header.%s in flow %s", header.GetType(), header.GetPath(), flow.GetName()))
+		}
+	}
+
 	for key, property := range object.GetProperties() {
 		field := message.GetField(key)
 		if field == nil {

--- a/specs/strict/define_test.go
+++ b/specs/strict/define_test.go
@@ -43,6 +43,9 @@ func TestUnmarshalFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if len(manifest.Flows) > 0 {
+				// t.Log(manifest.Flows[0].GetCalls()[0].GetRequest().GetHeader())
+			}
 
 			clean := file.Name()[:len(file.Name())-len(filepath.Ext(file.Name()))]
 			file, err := os.Open(filepath.Join(file.Path, clean+".yaml"))

--- a/specs/strict/tests/header.fail.hcl
+++ b/specs/strict/tests/header.fail.hcl
@@ -1,0 +1,21 @@
+caller "http" {}
+
+service "caller" "http" {
+	host = ""
+	schema = "caller"
+	codec = "json"
+}
+
+flow "echo" {
+    input {
+        ammount = "<int32>"
+    }
+
+	call "opening" "caller.Open" {
+		request {
+			header {
+                Ammount = "{{ input:ammount }}"
+            }
+		}
+	}
+}

--- a/specs/strict/tests/header.fail.yaml
+++ b/specs/strict/tests/header.fail.yaml
@@ -1,0 +1,16 @@
+exception:
+    message: cannot use type int32 for header.Ammount in flow echo
+services:
+    caller:
+        methods:
+            Open:
+                input:
+                    fields:
+                        message:
+                            type: "string"
+                            label: "optional"
+                output:
+                    fields:
+                        message:
+                            type: "string"
+                            label: "optional"

--- a/specs/strict/tests/header.pass.hcl
+++ b/specs/strict/tests/header.pass.hcl
@@ -1,0 +1,23 @@
+caller "http" {}
+
+service "caller" "http" {
+	host = ""
+	schema = "caller"
+	codec = "json"
+}
+
+flow "echo" {
+    input {
+        header {
+            Authorization = "<string>"
+        }
+    }
+
+	call "opening" "caller.Open" {
+		request {
+			header {
+                Authorization = "{{ input.request.header:Authorization }}"
+            }
+		}
+	}
+}

--- a/specs/strict/tests/header.pass.yaml
+++ b/specs/strict/tests/header.pass.yaml
@@ -1,0 +1,14 @@
+services:
+    caller:
+        methods:
+            Open:
+                input:
+                    fields:
+                        message:
+                            type: "string"
+                            label: "optional"
+                output:
+                    fields:
+                        message:
+                            type: "string"
+                            label: "optional"


### PR DESCRIPTION
Additional type validations are required to ensure that all header properties are a string. This PR could be reviewed after #20 is merged.